### PR TITLE
suppress debug logs in default 

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -71,7 +71,7 @@ RUN sed -i -e 's/type/@type/g' /fluentd/etc/fluent.conf
 ENV JEMALLOC_PATH /usr/lib/x86_64-linux-gnu/libjemalloc.so.1
 ENV LD_PRELOAD $JEMALLOC_PATH
 
-ENV FLUENTD_ARGS="-v"
+ENV FLUENTD_ARGS=""
 ENV FLUENTD_CONF="fluent.conf"
 
 EXPOSE 24224 5140


### PR DESCRIPTION
'-v' is not suitable for published container images.  '-v' would produce unnecessary debug logs. this is not appropriate for default hehavior.  '-v' should be overridden by users.

